### PR TITLE
Warn when tmux mouse mode is disabled

### DIFF
--- a/docs/as-built/cli-reference.md
+++ b/docs/as-built/cli-reference.md
@@ -129,7 +129,7 @@ Usage: `rig doctor [--json]`
 Notes:
 - Verifies install health for packaged/local CLI usage.
 - Checks daemon dist, UI dist, Node version, `tmux`, optional `cmux` control health, writable state paths, and daemon port availability.
-- On macOS, also warns when tmux mouse mode appears disabled and recommends `tmux set -g mouse on` for better pane scrolling and selection.
+- On macOS, also warns when tmux mouse mode appears disabled, gives the current-server fix (`tmux set -g mouse on`), and points to the persistent fix in `~/.tmux.conf`.
 - `cmux` issues are warnings, not hard failures. OpenRig still works without `cmux`; only `Open CMUX` workflows are unavailable.
 - `--json` is suitable for agent use and only exits non-zero on real failures, not warnings.
 

--- a/docs/as-built/cli-reference.md
+++ b/docs/as-built/cli-reference.md
@@ -129,6 +129,7 @@ Usage: `rig doctor [--json]`
 Notes:
 - Verifies install health for packaged/local CLI usage.
 - Checks daemon dist, UI dist, Node version, `tmux`, optional `cmux` control health, writable state paths, and daemon port availability.
+- On macOS, also warns when tmux mouse mode appears disabled and recommends `tmux set -g mouse on` for better pane scrolling and selection.
 - `cmux` issues are warnings, not hard failures. OpenRig still works without `cmux`; only `Open CMUX` workflows are unavailable.
 - `--json` is suitable for agent use and only exits non-zero on real failures, not warnings.
 

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -105,7 +105,7 @@ export function runDoctorChecks(deps: DoctorDeps): { checks: DoctorCheck[]; port
           status: "warn",
           message: "tmux mouse mode appears disabled.",
           reason: "On macOS, scrolling and text selection inside tmux panes is much smoother with mouse mode enabled.",
-          fix: "Run: tmux set -g mouse on",
+          fix: "Run `tmux set -g mouse on` for the current tmux server. To keep it enabled, add `set -g mouse on` to `~/.tmux.conf` and reload with `tmux source-file ~/.tmux.conf`.",
         });
       }
     }

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -91,6 +91,24 @@ export function runDoctorChecks(deps: DoctorDeps): { checks: DoctorCheck[]; port
   try {
     const ver = deps.exec("tmux -V").trim();
     checks.push({ name: "tmux", status: "pass", message: ver });
+    if (platform === "darwin") {
+      const mouseMode = readTmuxMouseMode(deps);
+      if (mouseMode === "on") {
+        checks.push({
+          name: "tmux_mouse",
+          status: "pass",
+          message: "tmux mouse mode enabled.",
+        });
+      } else if (mouseMode === "off") {
+        checks.push({
+          name: "tmux_mouse",
+          status: "warn",
+          message: "tmux mouse mode appears disabled.",
+          reason: "On macOS, scrolling and text selection inside tmux panes is much smoother with mouse mode enabled.",
+          fix: "Run: tmux set -g mouse on",
+        });
+      }
+    }
   } catch {
     checks.push({
       name: "tmux",
@@ -177,6 +195,16 @@ function readCmuxSocketControlMode(deps: DoctorDeps): string | null {
   try {
     const mode = deps.exec("defaults read com.cmuxterm.app socketControlMode").trim();
     return mode || null;
+  } catch {
+    return null;
+  }
+}
+
+function readTmuxMouseMode(deps: DoctorDeps): "on" | "off" | null {
+  try {
+    const mode = deps.exec("tmux show-options -gqv mouse").trim().toLowerCase();
+    if (mode === "on" || mode === "off") return mode;
+    return null;
   } catch {
     return null;
   }

--- a/packages/cli/test/doctor.test.ts
+++ b/packages/cli/test/doctor.test.ts
@@ -74,10 +74,49 @@ describe("runDoctorChecks", () => {
   });
 
   it("tmux available -> pass", () => {
-    const deps = makeDeps({ exec: () => "tmux 3.4" });
+    const deps = makeDeps({
+      exec: (cmd: string) => {
+        if (cmd === "tmux -V") return "tmux 3.4\n";
+        if (cmd === "tmux show-options -gqv mouse") return "on\n";
+        return "";
+      },
+    });
     const { checks } = runDoctorChecks(deps);
     const tmuxCheck = checks.find((c) => c.name === "tmux");
     expect(tmuxCheck?.status).toBe("pass");
+  });
+
+  it("tmux mouse enabled on macOS -> pass", () => {
+    const deps = makeDeps({
+      exec: (cmd: string) => {
+        if (cmd === "tmux -V") return "tmux 3.4\n";
+        if (cmd === "tmux show-options -gqv mouse") return "on\n";
+        if (cmd === "cmux capabilities --json") return '{"capabilities":["surface.focus"]}\n';
+        if (cmd === "cmux --help") return "cmux help\n";
+        return "";
+      },
+    });
+    const { checks } = runDoctorChecks(deps);
+    const mouseCheck = checks.find((c) => c.name === "tmux_mouse");
+    expect(mouseCheck?.status).toBe("pass");
+    expect(mouseCheck?.message).toContain("enabled");
+  });
+
+  it("tmux mouse disabled on macOS -> warn with exact fix", () => {
+    const deps = makeDeps({
+      exec: (cmd: string) => {
+        if (cmd === "tmux -V") return "tmux 3.4\n";
+        if (cmd === "tmux show-options -gqv mouse") return "off\n";
+        if (cmd === "cmux capabilities --json") return '{"capabilities":["surface.focus"]}\n';
+        if (cmd === "cmux --help") return "cmux help\n";
+        return "";
+      },
+    });
+    const { checks } = runDoctorChecks(deps);
+    const mouseCheck = checks.find((c) => c.name === "tmux_mouse");
+    expect(mouseCheck?.status).toBe("warn");
+    expect(mouseCheck?.message).toContain("disabled");
+    expect(mouseCheck?.fix).toContain("tmux set -g mouse on");
   });
 
   it("tmux missing -> fail with guidance", () => {
@@ -91,6 +130,20 @@ describe("runDoctorChecks", () => {
     const tmuxCheck = checks.find((c) => c.name === "tmux");
     expect(tmuxCheck?.status).toBe("fail");
     expect(tmuxCheck?.fix).toContain("brew");
+  });
+
+  it("tmux mouse check is omitted on non-macOS hosts", () => {
+    const deps = makeDeps({
+      platform: "linux",
+      exec: (cmd: string) => {
+        if (cmd === "tmux -V") return "tmux 3.4\n";
+        if (cmd === "cmux capabilities --json") return '{"capabilities":["surface.focus"]}\n';
+        if (cmd === "cmux --help") return "cmux help\n";
+        return "";
+      },
+    });
+    const { checks } = runDoctorChecks(deps);
+    expect(checks.find((c) => c.name === "tmux_mouse")).toBeUndefined();
   });
 
   it("cmux control available -> pass", () => {

--- a/packages/cli/test/doctor.test.ts
+++ b/packages/cli/test/doctor.test.ts
@@ -117,6 +117,8 @@ describe("runDoctorChecks", () => {
     expect(mouseCheck?.status).toBe("warn");
     expect(mouseCheck?.message).toContain("disabled");
     expect(mouseCheck?.fix).toContain("tmux set -g mouse on");
+    expect(mouseCheck?.fix).toContain("~/.tmux.conf");
+    expect(mouseCheck?.fix).toContain("tmux source-file ~/.tmux.conf");
   });
 
   it("tmux missing -> fail with guidance", () => {


### PR DESCRIPTION
## Summary
- add a macOS-specific `tmux_mouse` doctor check after tmux is detected
- warn when `tmux show-options -gqv mouse` reports `off`
- recommend the exact fix command: `tmux set -g mouse on`
- document the new warning in the as-built CLI reference

## Testing
- `npm run build --workspace packages/cli`
- `npm test --workspace packages/cli -- doctor`
- `npm test --workspace packages/cli`
- `node packages/cli/dist/index.js doctor --json | head -n 40`
  - verified `tmux_mouse` appears as a separate check and reports `pass` when mouse mode is enabled

## Notes
- the warning is non-blocking and macOS-only
- if tmux is missing entirely, the existing hard failure remains the relevant signal


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Diagnostic tool now includes a macOS check for tmux mouse mode, warning when disabled and suggesting how to enable it.

* **Documentation**
  * CLI diagnostic reference updated with macOS-specific guidance on enabling tmux mouse mode and persistent configuration hints.

* **Tests**
  * Added coverage for the macOS tmux mouse check and platform-specific behavior to ensure correct warnings and fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->