### PR TITLE
Guard tracked docs outside docs/as-built

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
   ],
   "scripts": {
     "build": "npm run build --workspaces",
-    "test": "npm run test --workspaces",
+    "test": "npm run test:repo && npm run test:workspaces",
+    "test:repo": "node --test scripts/*.test.mjs && node scripts/check-docs-guard.mjs",
+    "test:workspaces": "npm run test --workspaces",
     "lint": "tsc --noEmit --project packages/daemon/tsconfig.json && tsc --noEmit --project packages/ui/tsconfig.json && tsc --noEmit --project packages/cli/tsconfig.json",
     "build:package": "bash scripts/build-package.sh"
   },

--- a/scripts/check-docs-guard.mjs
+++ b/scripts/check-docs-guard.mjs
@@ -1,0 +1,38 @@
+import { execFileSync } from "node:child_process";
+
+export function findBlockedDocsPaths(paths) {
+  return [...new Set(paths)]
+    .filter((file) => file.startsWith("docs/"))
+    .filter((file) => !file.startsWith("docs/as-built/"))
+    .sort();
+}
+
+export function listTrackedDocsPaths(exec = execFileSync) {
+  const output = exec("git", ["ls-files", "docs/**"], { encoding: "utf8" });
+  return output
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+export function buildDocsGuardMessage(blockedPaths) {
+  const lines = [
+    "Blocked tracked docs paths detected outside docs/as-built/:",
+    ...blockedPaths.map((file) => `- ${file}`),
+    "",
+    "Only docs/as-built/ is allowed to be tracked.",
+    "Keep plans and local notes untracked under docs/ or move durable docs into docs/as-built/ if they truly belong in git.",
+  ];
+  return lines.join("\n");
+}
+
+export function main() {
+  const blockedPaths = findBlockedDocsPaths(listTrackedDocsPaths());
+  if (blockedPaths.length === 0) return;
+  console.error(buildDocsGuardMessage(blockedPaths));
+  process.exitCode = 1;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/scripts/check-docs-guard.test.mjs
+++ b/scripts/check-docs-guard.test.mjs
@@ -1,0 +1,28 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { buildDocsGuardMessage, findBlockedDocsPaths } from "./check-docs-guard.mjs";
+
+test("findBlockedDocsPaths allows docs/as-built and rejects other docs paths", () => {
+  const blocked = findBlockedDocsPaths([
+    "docs/as-built/architecture.md",
+    "docs/plans/2026-04-10-thing.md",
+    "docs/local/notes.md",
+    "README.md",
+    "docs/plans/2026-04-10-thing.md",
+  ]);
+
+  assert.deepEqual(blocked, [
+    "docs/local/notes.md",
+    "docs/plans/2026-04-10-thing.md",
+  ]);
+});
+
+test("buildDocsGuardMessage explains the policy and offending files", () => {
+  const message = buildDocsGuardMessage([
+    "docs/plans/example.md",
+  ]);
+
+  assert.match(message, /Blocked tracked docs paths/);
+  assert.match(message, /docs\/plans\/example\.md/);
+  assert.match(message, /Only docs\/as-built\//);
+});


### PR DESCRIPTION
## Summary
- add a repo-level docs guard script that fails if any tracked path exists under `docs/` outside `docs/as-built/`
- add a tiny node test covering the allow/deny logic and error message
- wire the guard into the root test entrypoint via `npm run test:repo`

## Testing
- `npm run test:repo`
- direct behavioral proof:
  - force-added `docs/plans/guard-proof.md` with `git add -f`
  - ran `node scripts/check-docs-guard.mjs`
  - verified it failed with the expected blocked-path message
  - removed the proof file from the index and worktree afterward
- `npm run build`

## Notes
- this prevents the exact mistake from the destroy PR: even a force-added ignored file under `docs/plans/` will now fail the repo guard
- root `npm test` on `main` is currently red in unrelated existing UI tests, so the new guard was verified directly with `npm run test:repo` plus a forced-add proof instead of claiming a clean full-suite pass
