### PR TITLE
Add optional docs field to RigSpec

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Optional:
 
 Both commands support `--json` for agent-driven workflows.
 
-`rig setup` and managed runtime boot may also modify runtime config to reduce permission and MCP friction:
+Managed runtime boot (during `rig up`) may modify runtime config to reduce permission and MCP friction. `rig setup` discloses these paths so agents know what was changed:
 - global Claude: `~/.claude/settings.json` for OpenRig command allowlisting
 - global Claude state: `~/.claude.json` for managed workspace trust and onboarding completion
 - project Claude: `.claude/settings.local.json` for managed-session permissions

--- a/README.md
+++ b/README.md
@@ -126,6 +126,15 @@ Optional:
 
 Both commands support `--json` for agent-driven workflows.
 
+`rig setup` and managed runtime boot may also modify runtime config to reduce permission and MCP friction:
+- global Claude: `~/.claude/settings.json` for OpenRig command allowlisting
+- global Claude state: `~/.claude.json` for managed workspace trust and onboarding completion
+- project Claude: `.claude/settings.local.json` for managed-session permissions
+- project Claude MCP: `.mcp.json` for OpenRig-managed MCP servers
+- global Codex: `~/.codex/config.toml` for workspace trust and MCP servers
+
+Already-running adopted sessions may need restart before they pick up newly written runtime config.
+
 **For agents:** Ask the user whether they want core setup (`rig setup`) or the fuller workstation path (`rig setup --full`) before choosing the invocation. Inspect the result with `--json` and use `rig doctor` to finish any remaining machine-specific issues.
 
 ## Comparison with Claude Managed Agents

--- a/docs/reference/agent-startup-guide.md
+++ b/docs/reference/agent-startup-guide.md
@@ -241,6 +241,25 @@ For anything beyond `guidance_merge`, `skill_install`, and `send_text`, the reco
 
 This way, when deterministic support becomes fully reliable, the agent will boot up, see that everything is already set up (by the deterministic path), run its system check, confirm everything looks good, and proceed. Until then, the agent reads the instructions and handles the setup itself.
 
+### Runtime Config Disclosure
+
+OpenRig now performs some best-effort deterministic runtime configuration for managed sessions. These writes are intentionally invasive and should be disclosed plainly:
+
+- Claude global config: `~/.claude/settings.json`
+  Purpose: allow `rig` commands without repeated Claude permission prompts.
+- Claude global state: `~/.claude.json`
+  Purpose: pre-trust managed workspaces and mark onboarding complete for fresh managed sessions.
+- Claude project-local config: `.claude/settings.local.json`
+  Purpose: apply managed-session Claude permissions inside the project without committing them to git.
+- Claude project-local MCP config: `.mcp.json`
+  Purpose: configure OpenRig-managed MCP servers for Claude in that project.
+- Codex global config: `~/.codex/config.toml`
+  Purpose: pre-trust managed workspaces and configure Codex MCP servers. Codex currently has no equivalent project-local MCP config path.
+
+Two important caveats:
+- these writes are best-effort and should still be paired with startup guidance so the local agent can verify and repair them if needed
+- already-running adopted sessions may need restart before they pick up newly written config
+
 ### Runtime Differences
 
 **Claude Code:**

--- a/docs/reference/rig-spec.md
+++ b/docs/reference/rig-spec.md
@@ -37,6 +37,10 @@ summary: A full product squad with orchestration, development, and review pods.
 
 culture_file: culture/CULTURE.md
 
+docs:
+  - path: SETUP.md
+  - path: README.md
+
 startup:
   files:
     - path: guidance/team-norms.md
@@ -170,6 +174,7 @@ edges:
 | `name` | string | yes | — | Rig name. Used in session naming (`{pod}-{member}@{name}`), snapshot identification, and spec library lookup. |
 | `summary` | string | no | — | Human-readable description. Shown in spec library, review surfaces, and `rig specs show`. |
 | `culture_file` | string | no | — | Relative path to a rig-wide culture/constitution file. Must be a safe relative path (no `..`, no absolute). |
+| `docs` | Doc[] | no | — | Documentation files that should travel with the rig. Included in rig bundles. Each entry has a `path` field (safe relative path). The engine does not consume these — they are for humans and agents setting up the environment before launch. |
 | `startup` | StartupBlock | no | — | Rig-level startup files and actions. Applied to all members via the startup layering model. |
 | `services` | ServicesBlock | no | — | Optional managed services (Docker Compose). When present, services boot before any agent launches. |
 | `pods` | Pod[] | yes | — | At least one pod required. Each pod is a bounded context containing members and pod-local edges. |

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -77,7 +77,7 @@ const RUNTIME_CONFIG_DISCLOSURE: RuntimeConfigDisclosure[] = [
     scope: "project",
     runtime: "claude-code",
     path: ".claude/settings.local.json",
-    purpose: "Apply managed-session Claude permissions within the project.",
+    purpose: "Apply managed-session Claude permissions and context-collector statusLine config within the project.",
   },
   {
     scope: "project",

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -22,11 +22,19 @@ export interface VerificationCheck {
   fix?: string;
 }
 
+export interface RuntimeConfigDisclosure {
+  scope: "global" | "project";
+  runtime: "claude-code" | "codex";
+  path: string;
+  purpose: string;
+}
+
 export interface SetupResult {
   profile: "core" | "full";
   platform: string;
   ready: boolean;
   steps: SetupStep[];
+  runtimeConfig: RuntimeConfigDisclosure[];
   verification?: {
     checks: VerificationCheck[];
   };
@@ -52,6 +60,38 @@ const CORE_STEP_IDS = [
   "verify",
 ];
 const FULL_EXTRA_STEP_IDS = ["jq_install", "gh_install"];
+const RUNTIME_CONFIG_DISCLOSURE: RuntimeConfigDisclosure[] = [
+  {
+    scope: "global",
+    runtime: "claude-code",
+    path: "~/.claude/settings.json",
+    purpose: "Allow OpenRig commands without Claude permission prompts.",
+  },
+  {
+    scope: "global",
+    runtime: "claude-code",
+    path: "~/.claude.json",
+    purpose: "Pre-trust managed workspaces and mark Claude onboarding complete.",
+  },
+  {
+    scope: "project",
+    runtime: "claude-code",
+    path: ".claude/settings.local.json",
+    purpose: "Apply managed-session Claude permissions within the project.",
+  },
+  {
+    scope: "project",
+    runtime: "claude-code",
+    path: ".mcp.json",
+    purpose: "Configure project-local MCP servers for Claude-managed workspaces.",
+  },
+  {
+    scope: "global",
+    runtime: "codex",
+    path: "~/.codex/config.toml",
+    purpose: "Pre-trust managed workspaces and configure Codex MCP servers.",
+  },
+];
 
 function defaultDeps(): SetupDeps {
   return {
@@ -72,7 +112,7 @@ export async function runSetup(deps: SetupDeps, opts: { dryRun?: boolean; full?:
     for (const id of stepIds) {
       steps.push({ id, status: "skipped", message: `Dry run: ${id} would be attempted.` });
     }
-    return { profile, platform, ready: false, steps };
+    return { profile, platform, ready: false, steps, runtimeConfig: RUNTIME_CONFIG_DISCLOSURE };
   }
 
   // Core steps
@@ -313,7 +353,7 @@ export async function runSetup(deps: SetupDeps, opts: { dryRun?: boolean; full?:
   const stepsFailed = steps.some((s) => s.status === "fail");
   const verificationFailed = verification?.checks.some((c) => c.status === "fail") ?? false;
   const ready = !stepsFailed && !verificationFailed;
-  return { profile, platform, ready, steps, ...(verification ? { verification } : {}) };
+  return { profile, platform, ready, steps, runtimeConfig: RUNTIME_CONFIG_DISCLOSURE, ...(verification ? { verification } : {}) };
 }
 
 function buildDefaultDoctorDeps(setupDeps: SetupDeps): DoctorDeps {
@@ -359,6 +399,11 @@ export function setupCommand(depsOverride?: SetupDeps): Command {
 
       console.log(`\nProfile: ${result.profile}`);
       console.log(`Platform: ${result.platform}\n`);
+      console.log("OpenRig may modify runtime config in these locations:");
+      for (const item of result.runtimeConfig) {
+        console.log(`  - [${item.scope}] ${item.runtime} ${item.path} — ${item.purpose}`);
+      }
+      console.log("  - Note: already-running adopted sessions may need restart to pick up runtime config changes.\n");
 
       for (const step of result.steps) {
         const icon = step.status === "pass" ? "OK" : step.status === "applied" ? "APPLIED" : step.status === "warn" ? "WARN" : step.status === "skipped" ? "SKIP" : "FAIL";

--- a/packages/cli/test/setup.test.ts
+++ b/packages/cli/test/setup.test.ts
@@ -41,6 +41,42 @@ function captureLogs(fn: () => Promise<void>): Promise<{ logs: string[]; exitCod
     .finally(() => { console.log = orig; });
 }
 
+function expectRuntimeConfigDisclosure(result: SetupResult): void {
+  expect(result.runtimeConfig).toHaveLength(5);
+  expect(result.runtimeConfig).toEqual(expect.arrayContaining([
+    {
+      scope: "global",
+      runtime: "claude-code",
+      path: "~/.claude/settings.json",
+      purpose: "Allow OpenRig commands without Claude permission prompts.",
+    },
+    {
+      scope: "global",
+      runtime: "claude-code",
+      path: "~/.claude.json",
+      purpose: "Pre-trust managed workspaces and mark Claude onboarding complete.",
+    },
+    {
+      scope: "project",
+      runtime: "claude-code",
+      path: ".claude/settings.local.json",
+      purpose: expect.stringContaining("statusLine"),
+    },
+    {
+      scope: "project",
+      runtime: "claude-code",
+      path: ".mcp.json",
+      purpose: "Configure project-local MCP servers for Claude-managed workspaces.",
+    },
+    {
+      scope: "global",
+      runtime: "codex",
+      path: "~/.codex/config.toml",
+      purpose: "Pre-trust managed workspaces and configure Codex MCP servers.",
+    },
+  ]));
+}
+
 describe("rig setup", () => {
   it("wired via createProgram", async () => {
     const { createProgram } = await import("../src/index.js");
@@ -76,13 +112,7 @@ describe("rig setup", () => {
     expect(stepIds).not.toContain("gh_install");
     // All steps should be skipped in dry run
     expect(result.steps.every((s) => s.status === "skipped")).toBe(true);
-    expect(result.runtimeConfig).toEqual([
-      { scope: "global", runtime: "claude-code", path: "~/.claude/settings.json", purpose: "Allow OpenRig commands without Claude permission prompts." },
-      { scope: "global", runtime: "claude-code", path: "~/.claude.json", purpose: "Pre-trust managed workspaces and mark Claude onboarding complete." },
-      { scope: "project", runtime: "claude-code", path: ".claude/settings.local.json", purpose: "Apply managed-session Claude permissions within the project." },
-      { scope: "project", runtime: "claude-code", path: ".mcp.json", purpose: "Configure project-local MCP servers for Claude-managed workspaces." },
-      { scope: "global", runtime: "codex", path: "~/.codex/config.toml", purpose: "Pre-trust managed workspaces and configure Codex MCP servers." },
-    ]);
+    expectRuntimeConfigDisclosure(result);
   });
 
   it("--dry-run --full --json includes full profile with core + extra step ids", async () => {
@@ -335,13 +365,7 @@ describe("rig setup", () => {
 
     const result = await runSetup(deps, {});
 
-    expect(result.runtimeConfig).toEqual([
-      { scope: "global", runtime: "claude-code", path: "~/.claude/settings.json", purpose: "Allow OpenRig commands without Claude permission prompts." },
-      { scope: "global", runtime: "claude-code", path: "~/.claude.json", purpose: "Pre-trust managed workspaces and mark Claude onboarding complete." },
-      { scope: "project", runtime: "claude-code", path: ".claude/settings.local.json", purpose: "Apply managed-session Claude permissions within the project." },
-      { scope: "project", runtime: "claude-code", path: ".mcp.json", purpose: "Configure project-local MCP servers for Claude-managed workspaces." },
-      { scope: "global", runtime: "codex", path: "~/.codex/config.toml", purpose: "Pre-trust managed workspaces and configure Codex MCP servers." },
-    ]);
+    expectRuntimeConfigDisclosure(result);
   });
 
   it("ready is false only when setup steps or verification checks have fail status", async () => {

--- a/packages/cli/test/setup.test.ts
+++ b/packages/cli/test/setup.test.ts
@@ -76,6 +76,13 @@ describe("rig setup", () => {
     expect(stepIds).not.toContain("gh_install");
     // All steps should be skipped in dry run
     expect(result.steps.every((s) => s.status === "skipped")).toBe(true);
+    expect(result.runtimeConfig).toEqual([
+      { scope: "global", runtime: "claude-code", path: "~/.claude/settings.json", purpose: "Allow OpenRig commands without Claude permission prompts." },
+      { scope: "global", runtime: "claude-code", path: "~/.claude.json", purpose: "Pre-trust managed workspaces and mark Claude onboarding complete." },
+      { scope: "project", runtime: "claude-code", path: ".claude/settings.local.json", purpose: "Apply managed-session Claude permissions within the project." },
+      { scope: "project", runtime: "claude-code", path: ".mcp.json", purpose: "Configure project-local MCP servers for Claude-managed workspaces." },
+      { scope: "global", runtime: "codex", path: "~/.codex/config.toml", purpose: "Pre-trust managed workspaces and configure Codex MCP servers." },
+    ]);
   });
 
   it("--dry-run --full --json includes full profile with core + extra step ids", async () => {
@@ -321,6 +328,20 @@ describe("rig setup", () => {
     // Doctor statuses used as-is, not renamed
     const nodeCheck = result.verification!.checks.find((c) => c.name === "node_version");
     expect(["pass", "warn", "fail", "skipped"]).toContain(nodeCheck?.status);
+  });
+
+  it("non-dry-run results include the same structured runtime config disclosure", async () => {
+    const deps = makeDeps();
+
+    const result = await runSetup(deps, {});
+
+    expect(result.runtimeConfig).toEqual([
+      { scope: "global", runtime: "claude-code", path: "~/.claude/settings.json", purpose: "Allow OpenRig commands without Claude permission prompts." },
+      { scope: "global", runtime: "claude-code", path: "~/.claude.json", purpose: "Pre-trust managed workspaces and mark Claude onboarding complete." },
+      { scope: "project", runtime: "claude-code", path: ".claude/settings.local.json", purpose: "Apply managed-session Claude permissions within the project." },
+      { scope: "project", runtime: "claude-code", path: ".mcp.json", purpose: "Configure project-local MCP servers for Claude-managed workspaces." },
+      { scope: "global", runtime: "codex", path: "~/.codex/config.toml", purpose: "Pre-trust managed workspaces and configure Codex MCP servers." },
+    ]);
   });
 
   it("ready is false only when setup steps or verification checks have fail status", async () => {

--- a/packages/daemon/src/adapters/claude-code-adapter.ts
+++ b/packages/daemon/src/adapters/claude-code-adapter.ts
@@ -404,7 +404,9 @@ export class ClaudeCodeAdapter implements RuntimeAdapter {
     try {
       if (!this.fs.exists(path)) return {};
       const parsed = JSON.parse(this.fs.readFile(path));
-      return typeof parsed === "object" && parsed !== null ? parsed as Record<string, unknown> : {};
+      return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+        ? parsed as Record<string, unknown>
+        : {};
     } catch {
       return {};
     }
@@ -467,20 +469,10 @@ export class ClaudeCodeAdapter implements RuntimeAdapter {
     const settingsPath = nodePath.join(binding.cwd, ".claude", "settings.local.json");
     this.fs.mkdirp(nodePath.dirname(settingsPath));
 
-    let existing: Record<string, unknown> = {};
-    try {
-      if (this.fs.exists(settingsPath)) {
-        existing = JSON.parse(this.fs.readFile(settingsPath));
-      }
-    } catch { /* corrupt file — overwrite */ }
-
-    // Merge permissions: allowlist rig commands, common dev tools, and file ops
-    const existingPermissions = (typeof existing["permissions"] === "object" && existing["permissions"] !== null)
-      ? existing["permissions"] as Record<string, unknown>
-      : {};
-
-    const existingAllow = Array.isArray(existingPermissions["allow"]) ? existingPermissions["allow"] as string[] : [];
-    const existingDeny = Array.isArray(existingPermissions["deny"]) ? existingPermissions["deny"] as string[] : [];
+    const existing = this.readJsonObject(settingsPath);
+    const existingPermissions = this.readJsonObjectField(existing, "permissions");
+    const existingAllow = this.readStringArray(existingPermissions["allow"]);
+    const existingDeny = this.readStringArray(existingPermissions["deny"]);
 
     const rigAllowRules = [
       "Bash(rig:*)",
@@ -511,16 +503,8 @@ export class ClaudeCodeAdapter implements RuntimeAdapter {
 
     // Merge MCP config: ensure Exa and Context7 are configured at project level
     const mcpPath = nodePath.join(binding.cwd, ".mcp.json");
-    let mcpConfig: Record<string, unknown> = {};
-    try {
-      if (this.fs.exists(mcpPath)) {
-        mcpConfig = JSON.parse(this.fs.readFile(mcpPath));
-      }
-    } catch { /* corrupt — overwrite */ }
-
-    const mcpServers = (typeof mcpConfig["mcpServers"] === "object" && mcpConfig["mcpServers"] !== null)
-      ? mcpConfig["mcpServers"] as Record<string, unknown>
-      : {};
+    const mcpConfig = this.readJsonObject(mcpPath);
+    const mcpServers = this.readJsonObjectField(mcpConfig, "mcpServers");
 
     // Add Exa and Context7 if not already configured
     if (!mcpServers["exa"]) {

--- a/packages/daemon/src/adapters/claude-code-adapter.ts
+++ b/packages/daemon/src/adapters/claude-code-adapter.ts
@@ -502,7 +502,7 @@ export class ClaudeCodeAdapter implements RuntimeAdapter {
 
     existing["permissions"] = {
       ...existingPermissions,
-      defaultMode: existingPermissions["defaultMode"] ?? "acceptEdits",
+      defaultMode: "acceptEdits", // Unconditional: managed sessions must not inherit restrictive modes
       allow: mergedAllow,
       deny: mergedDeny,
     };

--- a/packages/daemon/src/adapters/claude-code-adapter.ts
+++ b/packages/daemon/src/adapters/claude-code-adapter.ts
@@ -100,6 +100,11 @@ export class ClaudeCodeAdapter implements RuntimeAdapter {
       console.error(`[openrig] context collector provisioning warning: ${(err as Error).message}`);
     }
 
+    // Best-effort: provision permissions and MCP config for managed Claude sessions
+    try { this.provisionPermissionsAndMcps(binding); } catch (err) {
+      console.error(`[openrig] permissions/MCP provisioning warning: ${(err as Error).message}`);
+    }
+
     let delivered = 0;
     const failed: Array<{ path: string; error: string }> = [];
 
@@ -449,6 +454,84 @@ export class ClaudeCodeAdapter implements RuntimeAdapter {
     };
 
     this.fs.writeFile(settingsPath, JSON.stringify(existing, null, 2));
+  }
+
+  /**
+   * Best-effort: provision permissions allowlist and MCP config for managed Claude sessions.
+   * Merges into .claude/settings.local.json (project-level, gitignored).
+   * Idempotent: merge preserves existing settings.
+   */
+  private provisionPermissionsAndMcps(binding: { cwd?: string | null }): void {
+    if (!binding.cwd) return;
+
+    const settingsPath = nodePath.join(binding.cwd, ".claude", "settings.local.json");
+    this.fs.mkdirp(nodePath.dirname(settingsPath));
+
+    let existing: Record<string, unknown> = {};
+    try {
+      if (this.fs.exists(settingsPath)) {
+        existing = JSON.parse(this.fs.readFile(settingsPath));
+      }
+    } catch { /* corrupt file — overwrite */ }
+
+    // Merge permissions: allowlist rig commands, common dev tools, and file ops
+    const existingPermissions = (typeof existing["permissions"] === "object" && existing["permissions"] !== null)
+      ? existing["permissions"] as Record<string, unknown>
+      : {};
+
+    const existingAllow = Array.isArray(existingPermissions["allow"]) ? existingPermissions["allow"] as string[] : [];
+    const existingDeny = Array.isArray(existingPermissions["deny"]) ? existingPermissions["deny"] as string[] : [];
+
+    const rigAllowRules = [
+      "Bash(rig:*)",
+      "Bash(cat *)", "Bash(ls *)", "Bash(find *)", "Bash(grep *)",
+      "Bash(head *)", "Bash(tail *)", "Bash(wc *)",
+      "Bash(mkdir *)", "Bash(cp *)", "Bash(mv *)",
+      "Bash(node *)", "Bash(npx *)", "Bash(npm *)",
+      "Read", "Edit",
+    ];
+    const rigDenyRules = [
+      "Bash(git push*)", "Bash(git commit*)",
+      "Bash(rm -rf *)",
+      "Bash(gh pr *)",
+    ];
+
+    // Merge without duplicating
+    const mergedAllow = [...new Set([...existingAllow, ...rigAllowRules])];
+    const mergedDeny = [...new Set([...existingDeny, ...rigDenyRules])];
+
+    existing["permissions"] = {
+      ...existingPermissions,
+      defaultMode: existingPermissions["defaultMode"] ?? "acceptEdits",
+      allow: mergedAllow,
+      deny: mergedDeny,
+    };
+
+    this.fs.writeFile(settingsPath, JSON.stringify(existing, null, 2));
+
+    // Merge MCP config: ensure Exa and Context7 are configured at project level
+    const mcpPath = nodePath.join(binding.cwd, ".mcp.json");
+    let mcpConfig: Record<string, unknown> = {};
+    try {
+      if (this.fs.exists(mcpPath)) {
+        mcpConfig = JSON.parse(this.fs.readFile(mcpPath));
+      }
+    } catch { /* corrupt — overwrite */ }
+
+    const mcpServers = (typeof mcpConfig["mcpServers"] === "object" && mcpConfig["mcpServers"] !== null)
+      ? mcpConfig["mcpServers"] as Record<string, unknown>
+      : {};
+
+    // Add Exa and Context7 if not already configured
+    if (!mcpServers["exa"]) {
+      mcpServers["exa"] = { type: "http", url: "https://mcp.exa.ai/mcp" };
+    }
+    if (!mcpServers["context7"]) {
+      mcpServers["context7"] = { type: "http", url: "https://mcp.context7.com/mcp" };
+    }
+
+    mcpConfig["mcpServers"] = mcpServers;
+    this.fs.writeFile(mcpPath, JSON.stringify(mcpConfig, null, 2));
   }
 }
 

--- a/packages/daemon/src/adapters/codex-runtime-adapter.ts
+++ b/packages/daemon/src/adapters/codex-runtime-adapter.ts
@@ -97,6 +97,11 @@ export class CodexRuntimeAdapter implements RuntimeAdapter {
       console.error(`[openrig] codex bootstrap warning: ${(err as Error).message}`);
     }
 
+    // Best-effort: provision MCPs for managed Codex sessions
+    try { this.provisionMcps(); } catch (err) {
+      console.error(`[openrig] codex MCP provisioning warning: ${(err as Error).message}`);
+    }
+
     let delivered = 0;
     const failed: Array<{ path: string; error: string }> = [];
 
@@ -263,6 +268,35 @@ export class CodexRuntimeAdapter implements RuntimeAdapter {
 
     for (const trustKey of this.workspaceTrustKeys(cwd)) {
       content = upsertCodexProjectTrust(content, trustKey);
+    }
+
+    this.fs.writeFile(configPath, content);
+  }
+
+  /**
+   * Best-effort: ensure Exa and Context7 MCPs are configured for Codex.
+   * Appends to ~/.codex/config.toml if the MCP entries don't already exist.
+   */
+  private provisionMcps(): void {
+    const home = this.fs.homedir ?? os.homedir();
+    if (!home) return;
+
+    const configPath = nodePath.join(home, ".codex", "config.toml");
+    this.fs.mkdirp(nodePath.dirname(configPath));
+
+    let content = "";
+    try {
+      if (this.fs.exists(configPath)) content = this.fs.readFile(configPath);
+    } catch { content = ""; }
+
+    // Add Exa if not present
+    if (!content.includes('[mcp_servers.exa]')) {
+      content += '\n[mcp_servers.exa]\nurl = "https://mcp.exa.ai/mcp"\n';
+    }
+
+    // Add Context7 if not present
+    if (!content.includes('[mcp_servers.context7]')) {
+      content += '\n[mcp_servers.context7]\nurl = "https://mcp.context7.com/mcp"\n';
     }
 
     this.fs.writeFile(configPath, content);

--- a/packages/daemon/src/domain/pod-bundle-assembler.ts
+++ b/packages/daemon/src/domain/pod-bundle-assembler.ts
@@ -73,6 +73,13 @@ export class PodBundleAssembler {
       this.collectRigFile(rigSpec.cultureFile, opts.rigRoot, opts.outputDir, collectedFiles);
     }
 
+    // 2b2. Docs files
+    if (rigSpec.docs) {
+      for (const doc of rigSpec.docs) {
+        this.collectRigFile(doc.path, opts.rigRoot, opts.outputDir, collectedFiles);
+      }
+    }
+
     // 2c. Rig startup files
     this.collectStartupFiles(rigSpec.startup, opts.rigRoot, opts.outputDir, collectedFiles);
 

--- a/packages/daemon/src/domain/pod-bundle-assembler.ts
+++ b/packages/daemon/src/domain/pod-bundle-assembler.ts
@@ -73,9 +73,13 @@ export class PodBundleAssembler {
       this.collectRigFile(rigSpec.cultureFile, opts.rigRoot, opts.outputDir, collectedFiles);
     }
 
-    // 2b2. Docs files
+    // 2b2. Docs files — required when declared (unlike culture/startup which are optional)
     if (rigSpec.docs) {
       for (const doc of rigSpec.docs) {
+        const absPath = nodePath.resolve(opts.rigRoot, doc.path);
+        if (!this.fs.exists(absPath)) {
+          throw new Error(`Declared doc file not found: ${doc.path} (resolved to ${absPath}). Remove it from the docs field or create the file.`);
+        }
         this.collectRigFile(doc.path, opts.rigRoot, opts.outputDir, collectedFiles);
       }
     }

--- a/packages/daemon/src/domain/rigspec-codec.ts
+++ b/packages/daemon/src/domain/rigspec-codec.ts
@@ -16,6 +16,7 @@ export class RigSpecCodec {
     };
     if (spec.summary) doc["summary"] = spec.summary;
     if (spec.cultureFile) doc["culture_file"] = spec.cultureFile;
+    if (spec.docs && spec.docs.length > 0) doc["docs"] = spec.docs.map((d) => ({ path: d.path }));
     if (spec.startup) doc["startup"] = serializeStartupBlock(spec.startup);
 
     doc["pods"] = spec.pods.map((pod) => {

--- a/packages/daemon/src/domain/rigspec-schema.ts
+++ b/packages/daemon/src/domain/rigspec-schema.ts
@@ -56,6 +56,23 @@ export class RigSpecSchema {
       }
     }
 
+    // docs: optional array of documentation file paths
+    if (obj["docs"] !== undefined) {
+      if (!Array.isArray(obj["docs"])) {
+        errors.push("docs: must be an array");
+      } else {
+        for (let i = 0; i < (obj["docs"] as unknown[]).length; i++) {
+          const doc = (obj["docs"] as Record<string, unknown>[])[i]!;
+          if (!doc["path"] || typeof doc["path"] !== "string") {
+            errors.push(`docs[${i}].path: required non-empty string`);
+          } else {
+            const pathErr = validateSafePath(doc["path"] as string, `docs[${i}].path`);
+            if (pathErr) errors.push(pathErr);
+          }
+        }
+      }
+    }
+
     // rig-level startup
     if (obj["startup"] !== undefined) {
       errors.push(...validateStartupBlock(obj["startup"], "startup"));
@@ -121,11 +138,16 @@ export class RigSpecSchema {
         }))
       : [];
 
+    const docs = Array.isArray(raw["docs"])
+      ? (raw["docs"] as Record<string, unknown>[]).map((d) => ({ path: d["path"] as string }))
+      : undefined;
+
     return {
       version: raw["version"] as string,
       name: raw["name"] as string,
       summary: raw["summary"] as string | undefined,
       cultureFile: raw["culture_file"] as string | undefined,
+      docs,
       startup: raw["startup"] ? normalizeStartupBlock(raw["startup"]) : undefined,
       services: raw["services"] ? normalizeServicesBlock(raw["services"], raw["name"] as string) : undefined,
       pods,

--- a/packages/daemon/src/domain/rigspec-schema.ts
+++ b/packages/daemon/src/domain/rigspec-schema.ts
@@ -62,7 +62,12 @@ export class RigSpecSchema {
         errors.push("docs: must be an array");
       } else {
         for (let i = 0; i < (obj["docs"] as unknown[]).length; i++) {
-          const doc = (obj["docs"] as Record<string, unknown>[])[i]!;
+          const entry = (obj["docs"] as unknown[])[i];
+          if (!entry || typeof entry !== "object") {
+            errors.push(`docs[${i}]: must be an object with a path field`);
+            continue;
+          }
+          const doc = entry as Record<string, unknown>;
           if (!doc["path"] || typeof doc["path"] !== "string") {
             errors.push(`docs[${i}].path: required non-empty string`);
           } else {

--- a/packages/daemon/src/domain/types.ts
+++ b/packages/daemon/src/domain/types.ts
@@ -448,11 +448,16 @@ export interface RigSpecPod {
   edges: RigSpecPodEdge[];
 }
 
+export interface RigSpecDoc {
+  path: string;
+}
+
 export interface RigSpec {
   version: string;
   name: string;
   summary?: string;
   cultureFile?: string;
+  docs?: RigSpecDoc[];
   startup?: StartupBlock;
   services?: RigServicesSpec;
   pods: RigSpecPod[];

--- a/packages/daemon/test/claude-context-collector.test.ts
+++ b/packages/daemon/test/claude-context-collector.test.ts
@@ -333,6 +333,32 @@ describe("ClaudeCodeAdapter Context Collector Provisioning", () => {
     expect(Object.keys(mcpConfig.mcpServers).filter((id) => id === "context7")).toHaveLength(1);
   });
 
+  it("deliverStartup overrides existing restrictive defaultMode with acceptEdits for managed sessions", async () => {
+    // Seed a restrictive existing defaultMode that would block managed-session autonomy
+    written["/project/.claude/settings.local.json"] = JSON.stringify({
+      permissions: {
+        defaultMode: "denyAll",
+        allow: ["Read"],
+      },
+    });
+
+    const adapter = new ClaudeCodeAdapter({
+      tmux: mockTmux(),
+      fsOps: mockFsOps(),
+      stateDir: tmpDir,
+      collectorAssetPath: "/fake/collector.js",
+    });
+
+    await adapter.deliverStartup([], { cwd: "/project", tmuxSession: "dev-impl@test", nodeId: "n1" } as any);
+
+    const settings = JSON.parse(written["/project/.claude/settings.local.json"]!);
+    // Must unconditionally force acceptEdits — not inherit the restrictive mode
+    expect(settings.permissions.defaultMode).toBe("acceptEdits");
+    // Existing allow rules should be merged, not replaced
+    expect(settings.permissions.allow).toContain("Read");
+    expect(settings.permissions.allow).toContain("Bash(rig:*)");
+  });
+
   it("deliverStartup pre-seeds Claude workspace trust for the managed project", async () => {
     const adapter = new ClaudeCodeAdapter({
       tmux: mockTmux(),

--- a/packages/daemon/test/claude-context-collector.test.ts
+++ b/packages/daemon/test/claude-context-collector.test.ts
@@ -196,7 +196,7 @@ describe("ClaudeCodeAdapter Context Collector Provisioning", () => {
   });
 
   // T7: No provisioning without stateDir/collectorAssetPath
-  it("no provisioning when stateDir or collectorAssetPath is missing", async () => {
+  it("no collector provisioning when stateDir or collectorAssetPath is missing", async () => {
     const adapter = new ClaudeCodeAdapter({
       tmux: mockTmux(),
       fsOps: mockFsOps(),
@@ -205,8 +205,14 @@ describe("ClaudeCodeAdapter Context Collector Provisioning", () => {
 
     await adapter.deliverStartup([], { cwd: "/project", tmuxSession: "test", nodeId: "n1" } as any);
 
-    // No settings.local.json written
-    expect(written["/project/.claude/settings.local.json"]).toBeUndefined();
+    // Permissions/MCP may still be provisioned, but statusLine (collector) must not be
+    const settingsContent = written["/project/.claude/settings.local.json"];
+    if (settingsContent) {
+      const settings = JSON.parse(settingsContent);
+      expect(settings.statusLine).toBeUndefined();
+    }
+    // Collector script must not be written
+    expect(written["/project/.openrig/context-collector.cjs"]).toBeUndefined();
   });
 
   // T8: Existing settings.local.json with unrelated keys preserved
@@ -262,6 +268,69 @@ describe("ClaudeCodeAdapter Context Collector Provisioning", () => {
     expect(written[settingsPath]).toBeDefined();
     const settings = JSON.parse(written[settingsPath]!);
     expect(settings.permissions.allow).toContain("Bash(rig:*)");
+  });
+
+  it("deliverStartup provisions project-scope Claude permissions and MCP config without clobbering existing settings", async () => {
+    written["/project/.claude/settings.local.json"] = JSON.stringify({
+      customSetting: true,
+      permissions: {
+        allow: ["Bash(rig:*)", "Bash(npm *)"],
+        deny: ["Bash(git push*)"],
+      },
+    });
+    written["/project/.mcp.json"] = JSON.stringify({
+      mcpServers: {
+        existing: { type: "http", url: "https://example.com/mcp" },
+      },
+    });
+
+    const adapter = new ClaudeCodeAdapter({
+      tmux: mockTmux(),
+      fsOps: mockFsOps(),
+      stateDir: tmpDir,
+      collectorAssetPath: "/fake/collector.js",
+    });
+
+    await adapter.deliverStartup([], { cwd: "/project", tmuxSession: "dev-impl@test", nodeId: "n1" } as any);
+
+    const settings = JSON.parse(written["/project/.claude/settings.local.json"]!);
+    expect(settings.customSetting).toBe(true);
+    expect(settings.statusLine.type).toBe("command");
+    expect(settings.permissions.defaultMode).toBe("acceptEdits");
+    expect(settings.permissions.allow).toContain("Bash(rig:*)");
+    expect(settings.permissions.allow.filter((rule: string) => rule === "Bash(rig:*)")).toHaveLength(1);
+    expect(settings.permissions.allow).toContain("Read");
+    expect(settings.permissions.allow).toContain("Edit");
+    expect(settings.permissions.deny).toContain("Bash(git push*)");
+    expect(settings.permissions.deny).toContain("Bash(rm -rf *)");
+    expect(settings.permissions.deny).toContain("Bash(gh pr *)");
+
+    const mcpConfig = JSON.parse(written["/project/.mcp.json"]!);
+    expect(mcpConfig.mcpServers.existing.url).toBe("https://example.com/mcp");
+    expect(mcpConfig.mcpServers.exa.url).toBe("https://mcp.exa.ai/mcp");
+    expect(mcpConfig.mcpServers.context7.url).toBe("https://mcp.context7.com/mcp");
+  });
+
+  it("deliverStartup keeps project-local Claude permission and MCP rules idempotent across repeated startup", async () => {
+    const adapter = new ClaudeCodeAdapter({
+      tmux: mockTmux(),
+      fsOps: mockFsOps(),
+      stateDir: tmpDir,
+      collectorAssetPath: "/fake/collector.js",
+    });
+
+    await adapter.deliverStartup([], { cwd: "/project", tmuxSession: "dev-impl@test", nodeId: "n1" } as any);
+    await adapter.deliverStartup([], { cwd: "/project", tmuxSession: "dev-impl@test", nodeId: "n1" } as any);
+
+    const settings = JSON.parse(written["/project/.claude/settings.local.json"]!);
+    expect(settings.permissions.allow.filter((rule: string) => rule === "Read")).toHaveLength(1);
+    expect(settings.permissions.allow.filter((rule: string) => rule === "Edit")).toHaveLength(1);
+    expect(settings.permissions.allow.filter((rule: string) => rule === "Bash(rig:*)")).toHaveLength(1);
+    expect(settings.permissions.deny.filter((rule: string) => rule === "Bash(rm -rf *)")).toHaveLength(1);
+
+    const mcpConfig = JSON.parse(written["/project/.mcp.json"]!);
+    expect(Object.keys(mcpConfig.mcpServers).filter((id) => id === "exa")).toHaveLength(1);
+    expect(Object.keys(mcpConfig.mcpServers).filter((id) => id === "context7")).toHaveLength(1);
   });
 
   it("deliverStartup pre-seeds Claude workspace trust for the managed project", async () => {

--- a/packages/daemon/test/claude-context-collector.test.ts
+++ b/packages/daemon/test/claude-context-collector.test.ts
@@ -333,6 +333,31 @@ describe("ClaudeCodeAdapter Context Collector Provisioning", () => {
     expect(Object.keys(mcpConfig.mcpServers).filter((id) => id === "context7")).toHaveLength(1);
   });
 
+  it("deliverStartup recovers from array-valued settings.local.json and .mcp.json", async () => {
+    // Seed both files with JSON arrays (invalid for object merge)
+    written["/project/.claude/settings.local.json"] = "[]";
+    written["/project/.mcp.json"] = "[]";
+
+    const adapter = new ClaudeCodeAdapter({
+      tmux: mockTmux(),
+      fsOps: mockFsOps(),
+      stateDir: tmpDir,
+      collectorAssetPath: "/fake/collector.js",
+    });
+
+    await adapter.deliverStartup([], { cwd: "/project", tmuxSession: "dev-impl@test", nodeId: "n1" } as any);
+
+    // Settings must be a proper object with permissions, not a bare array
+    const settings = JSON.parse(written["/project/.claude/settings.local.json"]!);
+    expect(settings.permissions.defaultMode).toBe("acceptEdits");
+    expect(settings.permissions.allow).toContain("Bash(rig:*)");
+
+    // MCP config must be a proper object with mcpServers, not a bare array
+    const mcpConfig = JSON.parse(written["/project/.mcp.json"]!);
+    expect(mcpConfig.mcpServers.exa.url).toBe("https://mcp.exa.ai/mcp");
+    expect(mcpConfig.mcpServers.context7.url).toBe("https://mcp.context7.com/mcp");
+  });
+
   it("deliverStartup overrides existing restrictive defaultMode with acceptEdits for managed sessions", async () => {
     // Seed a restrictive existing defaultMode that would block managed-session autonomy
     written["/project/.claude/settings.local.json"] = JSON.stringify({

--- a/packages/daemon/test/codex-runtime-adapter.test.ts
+++ b/packages/daemon/test/codex-runtime-adapter.test.ts
@@ -341,4 +341,37 @@ describe("Codex runtime adapter", () => {
     expect(content).toContain('[projects."/tmp/workspace"]');
     expect(content).toContain('trust_level = "trusted"');
   });
+
+  it("deliverStartup provisions Codex MCP servers in the global config without clobbering trust entries", async () => {
+    const fs = mockFs({
+      "/home/tester/.codex/config.toml": '[projects."/tmp/workspace"]\ntrust_level = "trusted"\n',
+    });
+    const fsWithHome = { ...fs, homedir: "/home/tester" };
+    const adapter = new CodexRuntimeAdapter({ tmux: mockTmux(), fsOps: fsWithHome });
+
+    await adapter.deliverStartup([], makeBinding("/tmp/workspace"));
+
+    const store = (fsWithHome as unknown as { _store: Record<string, string> })._store;
+    const content = store["/home/tester/.codex/config.toml"];
+    expect(content).toContain('[projects."/tmp/workspace"]');
+    expect(content).toContain('trust_level = "trusted"');
+    expect(content).toContain('[mcp_servers.exa]');
+    expect(content).toContain('url = "https://mcp.exa.ai/mcp"');
+    expect(content).toContain('[mcp_servers.context7]');
+    expect(content).toContain('url = "https://mcp.context7.com/mcp"');
+  });
+
+  it("deliverStartup keeps Codex MCP sections idempotent across repeated startup", async () => {
+    const fs = mockFs({});
+    const fsWithHome = { ...fs, homedir: "/home/tester" };
+    const adapter = new CodexRuntimeAdapter({ tmux: mockTmux(), fsOps: fsWithHome });
+
+    await adapter.deliverStartup([], makeBinding("/tmp/workspace"));
+    await adapter.deliverStartup([], makeBinding("/tmp/workspace"));
+
+    const store = (fsWithHome as unknown as { _store: Record<string, string> })._store;
+    const content = store["/home/tester/.codex/config.toml"];
+    expect(content.match(/\[mcp_servers\.exa\]/g)?.length ?? 0).toBe(1);
+    expect(content.match(/\[mcp_servers\.context7\]/g)?.length ?? 0).toBe(1);
+  });
 });

--- a/packages/daemon/test/pod-bundle-assembler.test.ts
+++ b/packages/daemon/test/pod-bundle-assembler.test.ts
@@ -623,4 +623,50 @@ describe("PodBundleSourceResolver", () => {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   });
+
+  it("bundles declared docs files alongside the rig spec", () => {
+    const spec = makeRigSpec({ docs: [{ path: "SETUP.md" }] });
+    const yaml = rigSpecYaml(spec);
+    const files: Record<string, string> = {
+      [`${RIG_ROOT}/rig.yaml`]: yaml,
+      [`${RIG_ROOT}/SETUP.md`]: "# Setup instructions\nInstall Exa MCP first.",
+      [`${RIG_ROOT}/agents/impl/agent.yaml`]: validAgentYaml("impl"),
+    };
+    const fs = mockFs(files);
+    const assembler = new PodBundleAssembler({ fsOps: fs });
+
+    const result = assembler.assemble({
+      rigRoot: RIG_ROOT,
+      rigSpecPath: `${RIG_ROOT}/rig.yaml`,
+      outputDir: "/out",
+      bundleName: "test",
+      bundleVersion: "1.0",
+    });
+
+    expect(result.collectedFiles).toContain("SETUP.md");
+    // The bundled rig.yaml should still reference the doc
+    const written = (fs as unknown as { _written: Record<string, string> })._written;
+    const bundledRigYaml = written["/out/rig.yaml"];
+    expect(bundledRigYaml).toContain("SETUP.md");
+  });
+
+  it("fails assembly when a declared doc file is missing from disk", () => {
+    const spec = makeRigSpec({ docs: [{ path: "SETUP.md" }] });
+    const yaml = rigSpecYaml(spec);
+    const files: Record<string, string> = {
+      [`${RIG_ROOT}/rig.yaml`]: yaml,
+      // SETUP.md deliberately missing
+      [`${RIG_ROOT}/agents/impl/agent.yaml`]: validAgentYaml("impl"),
+    };
+    const fs = mockFs(files);
+    const assembler = new PodBundleAssembler({ fsOps: fs });
+
+    expect(() => assembler.assemble({
+      rigRoot: RIG_ROOT,
+      rigSpecPath: `${RIG_ROOT}/rig.yaml`,
+      outputDir: "/out",
+      bundleName: "test",
+      bundleVersion: "1.0",
+    })).toThrow(/Declared doc file not found.*SETUP\.md/);
+  });
 });

--- a/packages/daemon/test/rigspec-schema-docs.test.ts
+++ b/packages/daemon/test/rigspec-schema-docs.test.ts
@@ -62,4 +62,22 @@ describe("RigSpec docs field", () => {
     const spec = RigSpecSchema.normalize(minimalSpec());
     expect(spec.docs).toBeUndefined();
   });
+
+  it("rejects null entry in docs array without crashing", () => {
+    const result = RigSpecSchema.validate(minimalSpec({ docs: [null] }));
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes("docs[0]: must be an object"))).toBe(true);
+  });
+
+  it("rejects primitive entry in docs array without crashing", () => {
+    const result = RigSpecSchema.validate(minimalSpec({ docs: [42] }));
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes("docs[0]: must be an object"))).toBe(true);
+  });
+
+  it("rejects string entry in docs array without crashing", () => {
+    const result = RigSpecSchema.validate(minimalSpec({ docs: ["SETUP.md"] }));
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes("docs[0]: must be an object"))).toBe(true);
+  });
 });

--- a/packages/daemon/test/rigspec-schema-docs.test.ts
+++ b/packages/daemon/test/rigspec-schema-docs.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { RigSpecSchema } from "../src/domain/rigspec-schema.js";
+
+describe("RigSpec docs field", () => {
+  function minimalSpec(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+    return {
+      version: "0.2",
+      name: "test-rig",
+      pods: [
+        {
+          id: "dev",
+          label: "Development",
+          members: [
+            { id: "impl", agent_ref: "builtin:terminal", profile: "none", runtime: "terminal", cwd: "." },
+          ],
+          edges: [],
+        },
+      ],
+      edges: [],
+      ...overrides,
+    };
+  }
+
+  it("accepts a spec with no docs field", () => {
+    const result = RigSpecSchema.validate(minimalSpec());
+    expect(result.valid).toBe(true);
+  });
+
+  it("accepts a spec with valid docs array", () => {
+    const result = RigSpecSchema.validate(minimalSpec({
+      docs: [{ path: "SETUP.md" }, { path: "README.md" }],
+    }));
+    expect(result.valid).toBe(true);
+  });
+
+  it("rejects docs that is not an array", () => {
+    const result = RigSpecSchema.validate(minimalSpec({ docs: "SETUP.md" }));
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes("docs: must be an array"))).toBe(true);
+  });
+
+  it("rejects doc entry without path", () => {
+    const result = RigSpecSchema.validate(minimalSpec({ docs: [{}] }));
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes("docs[0].path: required"))).toBe(true);
+  });
+
+  it("rejects doc entry with path traversal", () => {
+    const result = RigSpecSchema.validate(minimalSpec({ docs: [{ path: "../../../etc/passwd" }] }));
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes("path traversal"))).toBe(true);
+  });
+
+  it("normalizes docs into typed array", () => {
+    const spec = RigSpecSchema.normalize(minimalSpec({
+      docs: [{ path: "SETUP.md" }, { path: "README.md" }],
+    }));
+    expect(spec.docs).toEqual([{ path: "SETUP.md" }, { path: "README.md" }]);
+  });
+
+  it("normalizes to undefined when no docs field present", () => {
+    const spec = RigSpecSchema.normalize(minimalSpec());
+    expect(spec.docs).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Add a top-level `docs` array field to the pod-aware RigSpec schema
- Documentation files listed in `docs` are included in rig bundles so setup instructions travel with the distributable artifact
- The engine does not consume these files for instantiation — they are metadata for humans and agents setting up the environment before launch

## Motivation
When distributing a rig bundle, setup instructions (permissions, MCPs, prerequisites) have no way to travel with the artifact. The human receiving the bundle needs a separate SETUP.md file. This field lets the rig spec declare which documentation files should be bundled.

## Changes
- `types.ts`: `RigSpecDoc` interface + `docs?` field on `RigSpec`
- `rigspec-schema.ts`: validation (array of objects with safe relative paths) + normalization
- `rigspec-codec.ts`: serialization
- `pod-bundle-assembler.ts`: collect listed docs into the bundle archive
- `docs/reference/rig-spec.md`: document the field
- 7 new tests covering validation, rejection, normalization, path safety

## Example
```yaml
version: "0.2"
name: my-rig
docs:
  - path: SETUP.md
  - path: README.md
pods:
  # ...
```

## Test plan
- [x] `npm test -w @openrig/daemon -- test/rigspec-schema-docs.test.ts` — 7/7 passing
- [x] Full daemon suite — 128 files, 1713/1713 passing
- [x] Validation: spec with docs validates, spec without docs validates, path traversal rejected, missing path rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rig specs can declare documentation files to include in bundles; bundling will copy declared docs and fail with a clear error if missing.
  * Setup now discloses runtime config file locations and tooling will perform best-effort provisioning/writes for Claude and Codex (may require restart).

* **Documentation**
  * Spec docs, agent startup guide, and README updated to document the docs field, runtime config disclosures, and caveats.

* **Tests**
  * Added tests covering docs validation/normalization, bundling behavior, provisioning, and idempotency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->