### PR TITLE
fix: clean transcript redraw and status noise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ notes/*
 .claude
 .agents
 .openrig
+.worktrees/
 
 # Local demo proof artifacts
 demo/proof/

--- a/packages/daemon/src/domain/transcript-store.ts
+++ b/packages/daemon/src/domain/transcript-store.ts
@@ -66,16 +66,16 @@ function isLikelyTuiFragment(line: string): boolean {
 }
 
 function stripOrphanCursorFragments(line: string): string {
-  return line.replace(/\[\d{1,3}[A-Za-z]/g, " ");
+  return line.replace(/\[\d{1,3}[A-Za-z](?=\S)/g, " ");
 }
 
 function isStatusOverlayLine(line: string): boolean {
   const trimmed = line.trim();
   if (!trimmed) return false;
   if (trimmed === "Checking for updates") return true;
-  if (/accept edits on/i.test(trimmed)) return true;
-  if (/background terminal running/i.test(trimmed)) return true;
-  if (/gpt-5\.4 xhigh fast/i.test(trimmed)) return true;
+  if (/^(?:[›⏵⏺❯]+\s*)?accept edits on\b.*\/clear to save\b.*tokens?$/i.test(trimmed)) return true;
+  if (/^\d+\s+background terminal running\b.*\/ps to view\b.*\/stop to close\b/i.test(trimmed)) return true;
+  if (/^gpt-[^\n]+ · Context \[[^\]]+\] · .+$/.test(trimmed)) return true;
   return false;
 }
 

--- a/packages/daemon/src/domain/transcript-store.ts
+++ b/packages/daemon/src/domain/transcript-store.ts
@@ -65,6 +65,20 @@ function isLikelyTuiFragment(line: string): boolean {
   return normalized.length <= 12;
 }
 
+function stripOrphanCursorFragments(line: string): string {
+  return line.replace(/\[\d{1,3}[A-Za-z]/g, " ");
+}
+
+function isStatusOverlayLine(line: string): boolean {
+  const trimmed = line.trim();
+  if (!trimmed) return false;
+  if (trimmed === "Checking for updates") return true;
+  if (/accept edits on/i.test(trimmed)) return true;
+  if (/background terminal running/i.test(trimmed)) return true;
+  if (/gpt-5\.4 xhigh fast/i.test(trimmed)) return true;
+  return false;
+}
+
 const TAIL_CHUNK_SIZE = 16 * 1024;
 
 /**
@@ -228,11 +242,13 @@ export class TranscriptStore {
     const normalizedLines = this.stripAnsi(rawText)
       .split("\n")
       .map((line) => stripShellPromptPrefix(line))
+      .map((line) => stripOrphanCursorFragments(line))
       .map((line) => line.trimEnd());
     const filtered = normalizedLines
       .filter((line) => line.trim() !== "")
       .filter((line) => !isBareShellPrompt(line));
     return filtered
+      .filter((line) => !isStatusOverlayLine(line))
       .filter((line) => !isUiChromeLine(line))
       .filter((line) => !isSpinnerOnlyLine(line))
       .filter((line) => !isLikelyTuiFragment(line))

--- a/packages/daemon/test/transcript-store.test.ts
+++ b/packages/daemon/test/transcript-store.test.ts
@@ -256,6 +256,62 @@ describe("TranscriptStore", () => {
       expect(result).not.toContain("Q  n");
       expect(result).not.toContain("u  z");
     });
+
+    it("removes orphaned cursor-motion fragments that survive without the ESC byte", () => {
+      const store = new TranscriptStore({ transcriptsRoot: tmpDir });
+      store.ensureTranscriptDir("my-rig");
+      const filePath = store.getTranscriptPath("my-rig", "dev@my-rig");
+      writeFileSync(
+        filePath,
+        [
+          "ok the current transcript snippet im looking at looks like this, it seems",
+          "like i should have spent a bit more time making sure the transcript was a",
+          "bit more cleaned up when we shipped v1 of rig transcript.  [2CHonest",
+          "[1Cframing: [1Cadding [1Cthe [1Cpack [1Cis [1Cmy [1Cdefault [1Cpattern",
+          "[1Cfrom [1Cthe [1Ctwo [1Cprior",
+          "[2Csuccessions; [1Cit's [1Chow [1CI [1Cstructured [1Clead2 [1C+ [1Corch-lead2",
+          "[2Cif [1Cyou [1Cwant [1Cminimal-wrapper [1Cfor [1Ca [1Cfresh-spawn [1Cnon-successor,",
+          "[2Cstrip [1Cit [1Cdown. [1CYour [1Ccall",
+          "[3Cconfirming [1Cthe [1Corder?",
+        ].join("\n") + "\n",
+      );
+
+      const result = store.readTail("my-rig", "dev@my-rig", 20);
+
+      expect(result).toContain("Honest");
+      expect(result).toContain("confirming");
+      expect(result).not.toContain("[1C");
+      expect(result).not.toContain("[2C");
+      expect(result).not.toContain("[3C");
+    });
+
+    it("drops repeated model status overlays from transcript tails", () => {
+      const store = new TranscriptStore({ transcriptsRoot: tmpDir });
+      store.ensureTranscriptDir("my-rig");
+      const filePath = store.getTranscriptPath("my-rig", "dev@my-rig");
+      writeFileSync(
+        filePath,
+        [
+          "  ⏵⏵ accept edits on (shift+tab to cycle)                 new task? /clear to save 248.6k tokens",
+          "                                                                            Checking for updates",
+          "  1 background terminal running · /ps to view · /stop to close",
+          "  gpt-5.4 xhigh fast · Context [█▏   ] · ~/code/substrate/shared-docs/rigs/kernel",
+          "OpenRig session identity:",
+          "- rig: kernel",
+          "- member: advisor-lead3",
+          "real transcript content should survive",
+        ].join("\n") + "\n",
+      );
+
+      const result = store.readTail("my-rig", "dev@my-rig", 20);
+
+      expect(result).toContain("OpenRig session identity:");
+      expect(result).toContain("real transcript content should survive");
+      expect(result).not.toContain("accept edits on");
+      expect(result).not.toContain("Checking for updates");
+      expect(result).not.toContain("background terminal running");
+      expect(result).not.toContain("gpt-5.4 xhigh fast");
+    });
   });
 
   describe("grep", () => {

--- a/packages/daemon/test/transcript-store.test.ts
+++ b/packages/daemon/test/transcript-store.test.ts
@@ -312,6 +312,44 @@ describe("TranscriptStore", () => {
       expect(result).not.toContain("background terminal running");
       expect(result).not.toContain("gpt-5.4 xhigh fast");
     });
+
+    it("preserves legitimate transcript sentences that mention overlay phrases", () => {
+      const store = new TranscriptStore({ transcriptsRoot: tmpDir });
+      store.ensureTranscriptDir("my-rig");
+      const filePath = store.getTranscriptPath("my-rig", "dev@my-rig");
+      writeFileSync(
+        filePath,
+        [
+          "Please accept edits on this proposal only after review.",
+          "The phrase background terminal running appears here as quoted text.",
+          "We were discussing the gpt-5.4 xhigh fast footer format yesterday.",
+        ].join("\n") + "\n",
+      );
+
+      const result = store.readTail("my-rig", "dev@my-rig", 20);
+
+      expect(result).toContain("Please accept edits on this proposal only after review.");
+      expect(result).toContain("The phrase background terminal running appears here as quoted text.");
+      expect(result).toContain("We were discussing the gpt-5.4 xhigh fast footer format yesterday.");
+    });
+
+    it("preserves literal cursor-fragment tokens when they are mentioned as data", () => {
+      const store = new TranscriptStore({ transcriptsRoot: tmpDir });
+      store.ensureTranscriptDir("my-rig");
+      const filePath = store.getTranscriptPath("my-rig", "dev@my-rig");
+      writeFileSync(
+        filePath,
+        [
+          "The artifact looked like literal [2C and [1C tokens in the transcript.",
+          "That exact text should survive cleanup.",
+        ].join("\n") + "\n",
+      );
+
+      const result = store.readTail("my-rig", "dev@my-rig", 20);
+
+      expect(result).toContain("literal [2C and [1C tokens");
+      expect(result).toContain("That exact text should survive cleanup.");
+    });
   });
 
   describe("grep", () => {


### PR DESCRIPTION
## Problem

`rig transcript` cleanup still leaks two important noise classes into the human-facing tail view:

- orphaned cursor fragments like `[1C`, `[2C`, and `[3C]` after the ESC byte is already gone
- repeated status overlays like `accept edits on`, `Checking for updates`, `background terminal running`, and `gpt-5.4 xhigh fast · Context ...`

This makes transcript tails harder to read and widens the gap between raw `pipe-pane` capture and the cleaned transcript surface agents and humans actually use.

## Root cause

`TranscriptStore.cleanupTailLines()` already filtered prompts, chrome, spinner-only lines, and likely TUI fragments, but it did not:

- normalize orphaned cursor-motion tokens that survived without the ESC byte
- drop these specific model/status overlay lines

## Scope

This PR keeps the change narrow:

- strip orphaned `[nX` cursor tokens during tail cleanup
- filter the observed status overlay lines from cleaned tails
- add regression tests for both behaviors
- add `.worktrees/` to `.gitignore` so repo-local worktrees are first-class for PR-first agent workflows

Deliberately out of scope:

- raw log rotation / compression / retention
- redesigning transcript architecture
- changing raw transcript capture semantics

## Evidence

Kernel-side research found substantial removable transcript noise in live logs, including the exact leaked fragment shape that motivated this fix.

Supporting local artifacts:

- `substrate/shared-docs/rigs/kernel/state/missions/transcript-cleanup-research/transcript-audit-latest.csv`
- `substrate/shared-docs/rigs/kernel/state/missions/transcript-cleanup-research/examples/advisor-lead3@kernel.clean.txt`
- `substrate/shared-docs/rigs/kernel/state/missions/transcript-cleanup-research/pm-build-handoff-2026-04-17.md`

## Verification

Commands run in this branch:

- `npm --workspace packages/daemon test -- test/transcript-store.test.ts`
- `npm --workspace packages/daemon test -- test/transcript-routes.test.ts`
- `npm --workspace packages/daemon test`

## Notes

The repo-root `npm test` path currently trips an unrelated docs-guard failure on tracked `docs/reference/*`. That baseline issue is outside this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session transcript cleanup by removing cursor motion artifacts and orphan cursor fragments, as well as filtering out ephemeral system status overlay messages (such as "Checking for updates", interactive prompts, and background terminal status indicators) from recorded sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->