### PR TITLE
docs: add release notes archive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ dist/
 docs/*
 !docs/as-built/
 !docs/reference/
+!docs/releases/
+!docs/releases/**
 
 notes/*
 

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -1,0 +1,65 @@
+# Release Notes
+
+This directory is the lightweight release history for OpenRig.
+
+It is intentionally simpler than a monolithic `CHANGELOG.md`.
+
+Each shipped release gets its own note:
+
+- `v0.1.12.md`
+- `v0.1.13.md`
+- and so on
+
+## Why This Exists
+
+We want a practical release-management pattern that works with how OpenRig is actually being shipped today:
+
+- npm package release
+- optional Git tag
+- optional GitHub Release
+- short, human-written summary of what is included
+
+This keeps release notes:
+
+- easy to author
+- easy to link in GitHub Releases
+- easy to paste into announcements
+- durable in the repo
+
+## Minimal Process
+
+For each release:
+
+1. Copy `_template.md` to `vX.Y.Z.md`.
+2. Fill in the release summary, included changes, operator notes, known limitations, and verification performed.
+3. Create a git tag for the release:
+
+   ```bash
+   git tag vX.Y.Z
+   git push origin vX.Y.Z
+   ```
+
+4. Create a GitHub Release using the same file:
+
+   ```bash
+   gh release create vX.Y.Z \
+     --repo mvschwarz/openrig \
+     --title "OpenRig vX.Y.Z" \
+     --notes-file docs/releases/vX.Y.Z.md
+   ```
+
+5. Publish the npm package if that is part of the release flow.
+
+## Guidance
+
+- Prefer user-facing language over commit-log language.
+- Group related fixes into a small number of bullets.
+- Be explicit about operator-impacting changes: setup, permissions, startup state, restore, recovery, and environment notes.
+- Keep internal refactors out unless they materially change user behavior or operator confidence.
+- If verification was limited, say so directly.
+
+## Scope
+
+This directory is a release-note archive, not a full historical changelog taxonomy.
+
+If OpenRig later wants a curated `CHANGELOG.md`, it can be generated or summarized from the release notes here.

--- a/docs/releases/_template.md
+++ b/docs/releases/_template.md
@@ -1,0 +1,38 @@
+# OpenRig vX.Y.Z
+
+## Summary
+
+One short paragraph describing the release at a human level.
+
+## Included In This Release
+
+- Change or fix cluster 1
+- Change or fix cluster 2
+- Change or fix cluster 3
+
+## User-Facing Changes
+
+- What users or operators will notice
+- What behavior is different now
+- Any new classifications, flows, or visible fixes
+
+## Operator / Setup Notes
+
+- Any upgrade, restart, or environment notes
+- Any migration or manual action notes
+- Any caveats for fresh installs or managed sessions
+
+## Known Limitations
+
+- Honest limitations that still exist after this release
+- Keep this short and specific
+
+## Verification Performed
+
+- Local targeted tests
+- VM or fresh-install validation
+- Manual operator-path verification
+
+## Commits Included
+
+- Optional: list the main commits if useful for maintainers

--- a/docs/releases/v0.1.12.md
+++ b/docs/releases/v0.1.12.md
@@ -1,0 +1,58 @@
+# OpenRig v0.1.12
+
+## Summary
+
+This release hardens startup-state truth, improves transcript cleanup, and makes restore/recovery behavior more reliable across Claude and Codex managed sessions.
+
+## Included In This Release
+
+- Normalize user-clearable startup blockers so they do not masquerade as hard failures.
+- Clear stale Claude startup/error residue more aggressively.
+- Improve Codex restore continuity detection and resume metadata capture.
+- Fix transcript redraw and status-noise cleanup.
+- Harden Claude managed-session startup around MCP-related blockers.
+- Improve operational reliability around tmux health and instantiate timing.
+
+## User-Facing Changes
+
+- Nodes blocked on interactive startup prompts are now normalized as user-clearable startup blockers instead of being left in misleading stale-failure states.
+- Claude startup state is cleaned up more aggressively when current runtime evidence proves the old failure residue is stale.
+- Codex restore behavior is more robust when resuming wrapped processes and when the TUI has scrolled or rendered extra footer/header noise.
+- Transcript cleanup is less noisy and better at removing redraw/status artifacts without leaving the terminal output in a confusing state.
+
+## Operator / Setup Notes
+
+- After upgrading, restart the daemon so new startup and restore behavior is active:
+
+  ```bash
+  rig daemon stop
+  rig daemon start
+  ```
+
+- This release improves classification and recovery behavior, but it does not turn every interrupted runtime into guaranteed native continuity. Operators should still treat restore results honestly and use manual recovery paths when the product says continuity could not be proved.
+
+## Known Limitations
+
+- Lifecycle/state handling is more truthful than before, but OpenRig still does not have a fully explicit infrastructure-grade state machine.
+- Restore remains runtime-specific and evidence-driven; some recovery paths still rely on heuristics rather than perfect provider-native primitives.
+
+## Verification Performed
+
+- Targeted daemon and CLI test coverage during the release workstream.
+- Focused review and validation of the transcript-cleanup change set.
+- Fresh-VM npm-install verification of the published `@openrig/cli` package, including daemon start, health route, doctor checks, `rig ps --nodes`, and UI load.
+
+## Commits Included
+
+- `8b07461` `cli: detect unhealthy tmux control sockets`
+- `8ca8e43` `daemon: ignore stale codex update banner once tui is live`
+- `a8adfe2` `daemon: capture codex resume ids from wrapped processes`
+- `e4619cf` `daemon: recognize resumed codex tui after header scrolls`
+- `30cf604` `daemon: accept codex footer with trailing blank lines`
+- `c44507f` `harden restore continuity and recovery guidance`
+- `105ed7e` `fix Claude MCP startup blockers for managed sessions`
+- `848b032` `cli: extend import instantiate timeout budget`
+- `43a0ace` `daemon: reject pod-aware node relaunch via legacy route`
+- `0d7e6ec` `daemon: normalize stale Claude startup state`
+- `37e2d5f` `daemon: normalize user-clearable startup blockers`
+- `74cf893` `fix: clean transcript redraw and status noise (#10)`


### PR DESCRIPTION
## Summary
- add a lightweight in-repo release notes archive under docs/releases
- add a reusable release note template
- backfill release notes for v0.1.12
- allow docs/releases to be tracked in git

## Why
We shipped npm releases without a durable repo-side release note history or GitHub Release note source file. This establishes a simple pattern that fits the current release process without introducing heavy changelog ceremony.

## Included
- docs/releases/README.md
- docs/releases/_template.md
- docs/releases/v0.1.12.md
- .gitignore carve-out for docs/releases/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Release notes archive established with structured, organized per-version documentation.
  * v0.1.12 release notes now available for reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->