### PR TITLE
fix(transport): heal the paste/submit draft race in verify path

### DIFF
--- a/packages/daemon/src/domain/session-transport.ts
+++ b/packages/daemon/src/domain/session-transport.ts
@@ -341,6 +341,49 @@ function countOccurrences(haystack: string, needle: string): number {
   return count;
 }
 
+// Issue #14 — draft-race healing constants. A C-m that outruns the TUI's
+// consumption of pasted bytes leaves the message sitting unsubmitted in the
+// composer; occurrence counting alone then reports it as rendered. These
+// bound the re-submit attempt: extra Enters on an already-delivered message
+// are inert in every supported TUI, so the bias is toward retrying.
+const SUBMIT_HEAL_MAX_EXTRA = 3;
+const SUBMIT_HEAL_SETTLE_MS = 400;
+
+function collapseWs(s: string): string {
+  return s.replace(/\s+/g, " ").trim();
+}
+
+/**
+ * True when `content` looks like the sent text is still parked unsubmitted in
+ * the seat's composer: the tail of the text occupies the pane's bottom line.
+ *
+ * Transcript echoes are excluded by prefix — delivered user messages render
+ * with a marker ("> ", "› ") and scroll above a fresh composer, while a stuck
+ * draft sits raw on the input line. Matching uses the last few characters of
+ * the text with whitespace collapsed, so composer wrapping does not defeat it.
+ */
+export function looksStuckInComposer(content: string | null, text: string): boolean {
+  if (!content || !text) return false;
+  const lines = content.split("\n");
+  let bottom = "";
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const raw = lines[i];
+    if (!raw) continue;
+    const t = collapseWs(raw);
+    if (t) {
+      bottom = t;
+      break;
+    }
+  }
+  if (!bottom) return false;
+  // A transcript echo of a DELIVERED message keeps its marker prefix.
+  if (/^(>|›)\s/.test(bottom)) return false;
+  const tailSource = collapseWs(text);
+  const needle = tailSource.slice(-12);
+  if (!needle) return false;
+  return bottom.includes(needle);
+}
+
 /** Map a resolved fan-out target + its recipient list → the EnvelopeScope (ruling 03c35295). The
  *  transport knows the target shape + resolved seats, so it builds the honest scale daemon-side:
  *  DM / multi (full list) / rig- or pod-scoped broadcast (with seat count) / topology. */
@@ -989,15 +1032,73 @@ export class SessionTransport {
     // middle outcome `rendered-unconfirmed` — never a failure (OPR.99.0.6.3).
     if (opts?.verify) {
       await this.sleep(500);
+      let content: string | null = null;
       try {
-        const content = await this.runStage(
+        content = await this.runStage(
           "session_transport.post_capture",
           () => this.tmuxAdapter.capturePaneContent(sessionName, 30),
         );
+      } catch {
+        content = null;
+      }
+
+      // Draft-race healing (issue #14): if the sent text's tail still occupies
+      // the pane's bottom line, Enter raced the paste render and the message is
+      // parked unsubmitted in the composer. Re-submit, bounded, with settle
+      // delays; occurrence counting alone cannot see this state because a raw
+      // draft satisfies it just as well as a delivered echo does.
+      let extraSubmits = 0;
+      while (
+        content !== null &&
+        looksStuckInComposer(content, text) &&
+        extraSubmits < SUBMIT_HEAL_MAX_EXTRA
+      ) {
+        await this.sleep(SUBMIT_HEAL_SETTLE_MS);
+        const retry = await this.runStage(
+          "session_transport.resubmit",
+          () => this.tmuxAdapter.sendKeys(sessionName, ["C-m"]),
+          (result) => (result.ok ? "ok" : "failed"),
+        );
+        if (!retry.ok) break;
+        extraSubmits++;
+        await this.sleep(SUBMIT_HEAL_SETTLE_MS);
+        try {
+          content = await this.runStage(
+            "session_transport.post_capture",
+            () => this.tmuxAdapter.capturePaneContent(sessionName, 30),
+          );
+        } catch {
+          break;
+        }
+      }
+      const stillStuck =
+        content !== null && looksStuckInComposer(content, text);
+
+      try {
+        if (content === null) {
+          // The original behavior: a throwing capture is the middle outcome,
+          // never a failure — unless a heal pass already proved stuckness.
+          content = await this.runStage(
+            "session_transport.post_capture",
+            () => this.tmuxAdapter.capturePaneContent(sessionName, 30),
+          );
+        }
         const snippet = text.substring(0, Math.min(text.length, 40));
         const preCount = countOccurrences(preVerifyContent ?? "", snippet);
         const postCount = countOccurrences(content ?? "", snippet);
-        const verified = postCount > preCount;
+        const verified = postCount > preCount && !stillStuck;
+        if (!verified && stillStuck) {
+          // A draft we could not clear after bounded re-submits is materially
+          // "text visible, not submitted": surface the same failure vocabulary.
+          return {
+            ok: false,
+            sessionName,
+            reason: "submit_failed",
+            outcome: "failed",
+            error: `Text remains unsubmitted in '${sessionName}' composer after ${1 + extraSubmits} submit attempts. The agent may need manual attention.`,
+            ...(waitMode ? { sent: true, ...waitEvidence } : {}),
+          };
+        }
         return { ok: true, sessionName, verified, outcome: verified ? "delivered" : "rendered-unconfirmed", ...(sendAdvisory ? { warning: sendAdvisory } : {}), ...(waitMode ? { sent: true, ...waitEvidence } : {}) };
       } catch {
         return { ok: true, sessionName, verified: false, outcome: "rendered-unconfirmed", ...(sendAdvisory ? { warning: sendAdvisory } : {}), ...(waitMode ? { sent: true, ...waitEvidence } : {}) };

--- a/packages/daemon/src/domain/session-transport.ts
+++ b/packages/daemon/src/domain/session-transport.ts
@@ -1032,15 +1032,20 @@ export class SessionTransport {
     // middle outcome `rendered-unconfirmed` — never a failure (OPR.99.0.6.3).
     if (opts?.verify) {
       await this.sleep(500);
-      let content: string | null = null;
-      try {
-        content = await this.runStage(
-          "session_transport.post_capture",
-          () => this.tmuxAdapter.capturePaneContent(sessionName, 30),
-        );
-      } catch {
-        content = null;
-      }
+      const tryCapture = async (): Promise<string | null> => {
+        try {
+          return await this.runStage(
+            "session_transport.post_capture",
+            () => this.tmuxAdapter.capturePaneContent(sessionName, 30),
+          );
+        } catch {
+          return null;
+        }
+      };
+      // A throwing first capture is usually a redraw race: one retry before
+      // giving up, so a draft visible behind the race still gets judged.
+      let content = await tryCapture();
+      if (content === null) content = await tryCapture();
 
       // Draft-race healing (issue #14): if the sent text's tail still occupies
       // the pane's bottom line, Enter raced the paste render and the message is
@@ -1062,26 +1067,18 @@ export class SessionTransport {
         if (!retry.ok) break;
         extraSubmits++;
         await this.sleep(SUBMIT_HEAL_SETTLE_MS);
-        try {
-          content = await this.runStage(
-            "session_transport.post_capture",
-            () => this.tmuxAdapter.capturePaneContent(sessionName, 30),
-          );
-        } catch {
-          break;
-        }
+        const next = await tryCapture();
+        if (next === null) break; // can no longer observe; stop rather than blind-fire Enters
+        content = next;
       }
       const stillStuck =
         content !== null && looksStuckInComposer(content, text);
 
       try {
         if (content === null) {
-          // The original behavior: a throwing capture is the middle outcome,
-          // never a failure — unless a heal pass already proved stuckness.
-          content = await this.runStage(
-            "session_transport.post_capture",
-            () => this.tmuxAdapter.capturePaneContent(sessionName, 30),
-          );
+          // Both capture attempts failed: the middle outcome, never a failure
+          // (OPR.99.0.6.3).
+          throw new Error("post-send capture unavailable");
         }
         const snippet = text.substring(0, Math.min(text.length, 40));
         const preCount = countOccurrences(preVerifyContent ?? "", snippet);

--- a/packages/daemon/test/session-transport.test.ts
+++ b/packages/daemon/test/session-transport.test.ts
@@ -456,8 +456,10 @@ describe("SessionTransport", () => {
 
   it("surfaces submit_failed when the draft persists after bounded retries", async () => {
     seedCanonicalRig();
+    const sendKeysSpy = vi.fn(async (_t: string, _keys: string[]) => ({ ok: true as const }));
     const tmux = mockTmux({
       capturePaneContent: async () => "prior output\n❯ unsubmitted tail here\n",
+      sendKeys: sendKeysSpy,
     });
     const transport = createTransport(tmux);
 
@@ -466,6 +468,8 @@ describe("SessionTransport", () => {
     expect(result.ok).toBe(false);
     expect(result.reason).toBe("submit_failed");
     expect(result.outcome).toBe("failed");
+    // One initial submit plus exactly SUBMIT_HEAL_MAX_EXTRA bounded retries.
+    expect(sendKeysSpy).toHaveBeenCalledTimes(4);
   });
 
   it("a transcript echo of a delivered message is never mistaken for a stuck draft", async () => {
@@ -475,8 +479,10 @@ describe("SessionTransport", () => {
       capturePaneContent: async () => {
         captureCount++;
         if (captureCount <= 2) return "idle prompt\n❯ ";
-        // Delivered: marker-prefixed echo happens to be the bottom line.
-        return "> hello\n❯ ";
+        // Delivered: the marker-prefixed echo sits AFTER the fresh prompt and
+        // IS the bottom line — the hardest case for the detector, which must
+        // exclude it by its marker rather than by position.
+        return "❯ \n> hello";
       },
     });
     const transport = createTransport(tmux);

--- a/packages/daemon/test/session-transport.test.ts
+++ b/packages/daemon/test/session-transport.test.ts
@@ -424,6 +424,69 @@ describe("SessionTransport", () => {
     expect(result.outcome).toBeUndefined();
   });
 
+  // Issue #14 — draft-race healing: a C-m that outruns the paste render leaves
+  // the message parked in the composer, and plain occurrence counting reports
+  // it as rendered (the reporter saw "Verified: yes" on a stuck draft).
+  it("re-submits when the sent text is still sitting in the composer", async () => {
+    seedCanonicalRig();
+    let captureCount = 0;
+    const sendKeysSpy = vi.fn(async (_t: string, _keys: string[]) => ({ ok: true as const }));
+    const tmux = mockTmux({
+      // Captures: readiness probe + pre-capture are idle; the first post-send
+      // capture shows the raw draft on the composer line; a later capture
+      // finally shows the delivered echo above a fresh prompt.
+      capturePaneContent: async () => {
+        captureCount++;
+        if (captureCount <= 2) return "idle prompt\n❯ ";
+        if (captureCount === 3) return "hello from the rig\n❯ hello from the rig\n"; // stuck draft
+        return "> hello from the rig\n❯ "; // delivered: marker echo + clear composer
+      },
+      sendKeys: sendKeysSpy,
+    });
+    const transport = createTransport(tmux);
+
+    const result = await transport.send("dev-impl@my-rig", "hello from the rig", { verify: true });
+
+    expect(result.ok).toBe(true);
+    expect(result.verified).toBe(true);
+    expect(result.outcome).toBe("delivered");
+    // Initial submit plus exactly one healing re-submit.
+    expect(sendKeysSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("surfaces submit_failed when the draft persists after bounded retries", async () => {
+    seedCanonicalRig();
+    const tmux = mockTmux({
+      capturePaneContent: async () => "prior output\n❯ unsubmitted tail here\n",
+    });
+    const transport = createTransport(tmux);
+
+    const result = await transport.send("dev-impl@my-rig", "unsubmitted tail here", { verify: true });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("submit_failed");
+    expect(result.outcome).toBe("failed");
+  });
+
+  it("a transcript echo of a delivered message is never mistaken for a stuck draft", async () => {
+    seedCanonicalRig();
+    let captureCount = 0;
+    const tmux = mockTmux({
+      capturePaneContent: async () => {
+        captureCount++;
+        if (captureCount <= 2) return "idle prompt\n❯ ";
+        // Delivered: marker-prefixed echo happens to be the bottom line.
+        return "> hello\n❯ ";
+      },
+    });
+    const transport = createTransport(tmux);
+
+    const result = await transport.send("dev-impl@my-rig", "hello", { verify: true });
+
+    expect(result.ok).toBe(true);
+    expect(result.outcome).toBe("delivered");
+  });
+
   // Test 7: send with mid-work detected → DELIVER WITH ADVISORY (OPR.0.4.3.28 fast-follow —
   // mid_work downgraded from a hard refuse to a non-blocking advisory; busy is not a block).
   it("send with mid-work detected DELIVERS with a non-blocking advisory (not a refusal)", async () => {


### PR DESCRIPTION
Fixes #14

## Root cause

Two defects combine in `SessionTransport.send()`:

1. The submit path is paste → fixed 200 ms sleep → `C-m`. Under load or with large payloads the TUI has not finished consuming the pasted bytes when Enter lands, so the message stays parked as a draft in the composer.
2. With `--verify`, delivery is judged by counting occurrences of the first 40 chars in a post-send capture. A stuck draft satisfies that count exactly like a delivered echo does, so the reporter saw `Verified: yes` on a message the agent never received.

## Change

Scoped to the verify path (non-verify sends keep their exact timing):

- After the first submit + settle, if the capture shows the sent text's tail still occupying the pane's bottom line, treat it as an unsubmitted draft and re-submit, bounded (`SUBMIT_HEAL_MAX_EXTRA = 3`, 400 ms settles).
- Transcript echoes are excluded by marker prefix (`"> "`, `"› "`): delivered messages render with a marker and scroll above a fresh composer; drafts sit raw on the input line. Tail matching collapses whitespace so composer line-wrapping does not defeat it; TUIs that visually truncate long drafts degrade gracefully to today's behavior.
- A draft that persists after the bounded retries now surfaces honestly as `ok: false / reason: "submit_failed" / outcome: "failed"` instead of a false ok — same vocabulary as the existing Enter-failed path.

## Verification

```
vitest run packages/daemon/test/session-transport.test.ts   # 68 passed (65 existing + 3 new)
vitest run packages/daemon/test/                            # 7378 passed; identical 13 pre-existing env failures on clean main
tsc --noEmit -p packages/daemon/tsconfig.json               # clean
```

New tests pin all three behaviors: heal-and-deliver (exactly one extra C-m), honest failure after exhausted retries, and no false positive when a marker-prefixed echo sits at the pane bottom. The heal test fails against the old code and passes with this change.

---
This change was prepared with AI assistance under human direction and review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved message delivery when text remains stuck in the composer during sending.
  - Automatically retries submission briefly before reporting failure.
  - Clearly reports when a message could not be submitted after retry attempts.
  - Prevents transcript echoes from being mistaken for unsent composer drafts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->